### PR TITLE
Stretch component syncs physics bodies

### DIFF
--- a/www/components/aframe-stretch.js
+++ b/www/components/aframe-stretch.js
@@ -98,12 +98,13 @@ AFRAME.registerComponent('stretch', {
     scale.scale(this.deltaStretch, scale);
     hitEl.setAttribute('scale', scale);
     // force scale update for physics body
-    if(hitEl.components['dynamic-body']) {
-      var physicsShape = hitEl.components['dynamic-body'].body.shapes[0];
-      physicsShape.halfExtents.set(hitElGeom.width / 2 * scale.x,
-                                   hitElGeom.height / 2 * scale.y,
-                                   hitElGeom.depth / 2 * scale.z);
-      physicsShape.updateConvexPolyhedronRepresentation();
+    if(hitEl.body) {
+      var physicsShape = hitEl.body.shapes[0];
+      if(physicsShape.halfExtents) {
+        physicsShape.halfExtents.set(hitElGeom.width / 2 * scale.x,
+                                     hitElGeom.height / 2 * scale.y,
+                                     hitElGeom.depth / 2 * scale.z);
+      }
       hitEl.body.updateBoundingRadius();
     }
     // need to update relationship of grabbing hand to object for a natural

--- a/www/components/aframe-stretch.js
+++ b/www/components/aframe-stretch.js
@@ -113,6 +113,7 @@ AFRAME.registerComponent('stretch', {
         physicsShape.halfExtents.set(hitElGeom.width / 2 * scale.x,
                                      hitElGeom.height / 2 * scale.y,
                                      hitElGeom.depth / 2 * scale.z);
+        physicsShape.updateConvexPolyhedronRepresentation();
       }
       hitEl.body.updateBoundingRadius();
     }

--- a/www/components/aframe-stretch.js
+++ b/www/components/aframe-stretch.js
@@ -69,6 +69,10 @@ AFRAME.registerComponent('stretch', {
   onGripOpen: function (evt) {
     var hitEl = this.hitEl;
     this.grabbing = false;
+    if(this.constraint) {
+      this.el.body.world.removeConstraint(this.constraint);
+      this.constraint = null;
+    }
     if (!hitEl) { return; }
     hitEl.removeState(this.STRETCHED_STATE);
     this.hitEl = undefined;
@@ -81,11 +85,16 @@ AFRAME.registerComponent('stretch', {
     // is grabbed by the other controller
     if(hitEl && this.grabbing && !this.hitEl &&
         !this.el.components.grab.hitEl &&
-       !hitEl.is(this.STRETCHED_STATE) &&
-       hitEl === this.otherController.components.grab.hitEl) {
-         hitEl.addState(this.STRETCHED_STATE);
-         this.hitEl = hitEl;
-       }
+        !hitEl.is(this.STRETCHED_STATE) &&
+        hitEl === this.otherController.components.grab.hitEl
+       ) {
+      hitEl.addState(this.STRETCHED_STATE);
+      this.hitEl = hitEl;
+      // adding a second constraint helps for a natural stretch feeling
+      // the body stays anchored at a midpoint between the two controllers
+      this.constraint = new CANNON.LockConstraint(this.el.body, hitEl.body);
+      this.el.body.world.addConstraint(this.constraint);
+    }
   },
   
   tick: function () {
@@ -107,8 +116,6 @@ AFRAME.registerComponent('stretch', {
       }
       hitEl.body.updateBoundingRadius();
     }
-    // need to update relationship of grabbing hand to object for a natural
-    // stretch feeling
 
   },
 


### PR DESCRIPTION
Fix #9 . Using a second lock constraint with the stretching controller keeps the object centered and its edges stretch with the two controllers. LockConstraint is still a bit awkward because it forces the object to rotate to face the controller, and could be improved upon. 