### PR TITLE
Add guides for color/shape/size

### DIFF
--- a/server.R
+++ b/server.R
@@ -18,6 +18,7 @@ shinyServer(function(input, output) {
                 y = "Sepal.Width",
                 z = "Petal.Length",
                 color = "Petal.Width",
+                size = "Petal.Width",
                 shape = "Species")
  
   selected_data <- reactive({

--- a/ui.R
+++ b/ui.R
@@ -105,16 +105,15 @@ shinyUI(fluidPage(
           `vive-controls`="hand: right",
           mixin = "controller"
         ),
-        aframeEntity(
-          id = "plotcontainer",
+        aScatter3dOutput(
+          "myplot",
           mixin = "plottheme",
           position = "0 1.5 0",
           rotation = "0 45 0",
           plot = "size: 0.5",
           `dynamic-body` = "shape: box;",
           sleepy = "angularDamping: 0; speedLimit: 1",
-          `collision-filter` = "group: plots;",
-          aScatter3dOutput("myplot")
+          `collision-filter` = "group: plots;"
         ),
         # aframeBox(
         #   position = "-1 1.5 -0.5",

--- a/www/components/aframe-plot.js
+++ b/www/components/aframe-plot.js
@@ -51,7 +51,7 @@ AFRAME.registerComponent('plot', {
       var guideEl = document.createElement('a-entity');
       this.guideArea.appendChild(guideEl);
       guideEl.setAttribute('plot-guide', { 
-        aesthetic: guide, size: (size - 0.1) / 3
+        aesthetic: guide, size: (size - 0.15) / 3
       });
       guideEl.plotEl = this.el;
       this.guides.push(guideEl);
@@ -405,20 +405,21 @@ AFRAME.registerComponent('plot-guide', {
     this.el.appendChild(this.hoverEl);
     this.hoverEl.className += ' hoverable';
     this.hoverEl.setAttribute('position', {
-      x: -0.75 * this.data.size,
-      y: this.data.size / 2 + ymarg / 2,
-      z: -0.001
+      x: -this.data.size,
+      y: this.data.size / 2 + ymarg / 2 + 0.01,
+      z: -0.0151
     });
-    this.hoverEl.setAttribute('width', this.data.size * 1.5);
-    this.hoverEl.setAttribute('height', this.data.size);
+    this.hoverEl.setAttribute('width', this.data.size * 2);
+    this.hoverEl.setAttribute('height', this.data.size + 0.02);
     this.hoverEl.setAttribute('color', 'white');
     this.hoverEl.setAttribute('static-body', '');
     this.hoverEl.setAttribute('visible', 'false');
     // guide title
     this.nameEl = document.createElement('a-entity');
     this.el.appendChild(this.nameEl);
-    this.nameEl.setAttribute('rotation', '0 0 90');
-    this.nameEl.setAttribute('position', '-0.2 0 0');
+    //this.nameEl.setAttribute('rotation', '0 0 90');
+    this.nameEl.setAttribute('position', {
+      x: -0.2, y: this.data.size + 0.0125, z: -0.015 });
     //layout for the labels v. keys
     this.legendEl = document.createElement('a-entity');
     this.el.appendChild(this.legendEl);
@@ -448,8 +449,10 @@ AFRAME.registerComponent('plot-guide', {
     while(this.labels.lastChild) {
       this.labels.removeChild(this.labels.lastChild);
     }
-    this.nameEl.setAttribute('scale', 
-                             new Array(4).join(this.data.fontScale + ' '));
+    this.nameEl.setAttribute(
+      'scale', 
+      new Array(4).join((this.data.fontScale + 0.01) + ' ')
+    );
     this.nameEl.setAttribute('bmfont-text', {
         text: this.data.name, mode: 'nowrap'
     });

--- a/www/components/aframe-plot.js
+++ b/www/components/aframe-plot.js
@@ -45,7 +45,7 @@ AFRAME.registerComponent('plot', {
       var guideEl = document.createElement('a-entity');
       this.guideArea.appendChild(guideEl);
       guideEl.setAttribute('plot-guide', { 
-        aesthetic: guide, size: size / 3
+        aesthetic: guide, size: (size - 0.06) / 3
       });
       this.guides.push(guideEl);
     });

--- a/www/components/aframe-plot.js
+++ b/www/components/aframe-plot.js
@@ -173,24 +173,17 @@ AFRAME.registerComponent('plot-axis', {
   },
   
   play: function () {
-    this.axis.addEventListener('stateadded', 
+    this.el.addEventListener('stateadded', 
                                this.hover.bind(this));
-    this.axis.addEventListener('stateremoved', 
+    this.el.addEventListener('stateremoved', 
                                this.unHover.bind(this));
-    this.mirror.addEventListener('stateadded', 
-                                 this.hover.bind(this));
-    this.mirror.addEventListener('stateremoved', 
-                                 this.unHover.bind(this));
+
   },
   pause: function () {
-    this.axis.removeEventListener('stateadded', 
+    this.el.removeEventListener('stateadded', 
                                   this.hover.bind(this));
-    this.axis.removeEventListener('stateremoved', 
+    this.el.removeEventListener('stateremoved', 
                                   this.unHover.bind(this));
-    this.mirror.removeEventListener('stateadded', 
-                                    this.hover.bind(this));
-    this.mirror.removeEventListener('stateremoved', 
-                                    this.unHover.bind(this));    
   },
   
   hover: function (evt) {

--- a/www/components/aframe-plot.js
+++ b/www/components/aframe-plot.js
@@ -389,7 +389,7 @@ AFRAME.registerComponent('plot-guide', {
     breaks: { default: [] },
     labels: { default: [] },
     size: { default: 1 },
-    fontScale: { default: 0.15 }
+    fontScale: { default: 0.14 }
   },
   init: function() {
     var ymarg = 0.02;
@@ -414,6 +414,11 @@ AFRAME.registerComponent('plot-guide', {
     this.hoverEl.setAttribute('color', 'white');
     this.hoverEl.setAttribute('static-body', '');
     this.hoverEl.setAttribute('visible', 'false');
+    // guide title
+    this.nameEl = document.createElement('a-entity');
+    this.el.appendChild(this.nameEl);
+    this.nameEl.setAttribute('rotation', '0 0 90');
+    this.nameEl.setAttribute('position', '-0.2 0 0');
     //layout for the labels v. keys
     this.legendEl = document.createElement('a-entity');
     this.el.appendChild(this.legendEl);
@@ -443,6 +448,11 @@ AFRAME.registerComponent('plot-guide', {
     while(this.labels.lastChild) {
       this.labels.removeChild(this.labels.lastChild);
     }
+    this.nameEl.setAttribute('scale', 
+                             new Array(4).join(this.data.fontScale + ' '));
+    this.nameEl.setAttribute('bmfont-text', {
+        text: this.data.name, mode: 'nowrap'
+    });
     this.marks.setAttribute('layout', 'margin', 
                          this.data.size / this.data.breaks.length);
     this.labels.setAttribute('layout', 'margin', 

--- a/www/components/aframe-plot.js
+++ b/www/components/aframe-plot.js
@@ -9,7 +9,16 @@ AFRAME.registerComponent('plot', {
     ybreaks: { default: [] },
     zname: {default: ''},
     zlabels: { default: [] },
-    zbreaks: { default: [] } 
+    zbreaks: { default: [] },
+    colorname: { default: '' },
+    colorbreaks: { default: [] },
+    colorlabels: { default: [] },
+    shapename: { default: '' },
+    shapebreaks: { default: [] },
+    shapelabels: { default: [] },
+    sizename: { default: '' },
+    sizebreaks: { default: [] },
+    sizelabels: { default: [] }
   },
   dependencies: ['geometry'],
   init: function() {
@@ -27,7 +36,7 @@ AFRAME.registerComponent('plot', {
     this.guideArea = document.createElement('a-entity');
     this.el.append(this.guideArea);
     this.guideArea.setAttribute('position', {
-      x: size / -2 - 0.1, y: size / -2 + 0.02, z: size / -2 - 0.1
+      x: size / -2 - 0.15, y: size / -2 + 0.02, z: size / -2 - 0.15
     });
     this.guideArea.setAttribute('rotation', '0 -45 0');
     this.guideArea.setAttribute('layout', 
@@ -35,13 +44,9 @@ AFRAME.registerComponent('plot', {
     ['color', 'shape', 'size'].forEach( (guide) => {
       var guideEl = document.createElement('a-entity');
       this.guideArea.appendChild(guideEl);
-      switch(guide) {
-        case 'color': testBreaks = ['red', 'yellow', 'blue']; break;
-        case 'size': testBreaks = [0.005, 0.01, 0.02]; break;
-        case 'shape': testBreaks = ['sphere', 'box', 'cone']; 
-      }
-      guideEl.setAttribute('plot-guide', { aesthetic: guide, size: size / 3,
-        breaks: testBreaks, labels: testBreaks});
+      guideEl.setAttribute('plot-guide', { 
+        aesthetic: guide, size: size / 3
+      });
       this.guides.push(guideEl);
     });
     
@@ -73,7 +78,18 @@ AFRAME.registerComponent('plot', {
       ax.setAttribute('plot-axis', 'breaks', newBreaks);
       ax.setAttribute('plot-axis', 'labels', newLabels);
 
-    }); 
+    });
+    this.guides.forEach( (guide) => {
+      if(!guide.components['plot-guide'].data) return;
+      aes = guide.components['plot-guide'].data.aesthetic;
+      guide.setAttribute('plot-guide', 
+        AFRAME.utils.extend(guide.getComputedAttribute('plot-guide'),
+        { name: this.data[aes + 'name'],
+          breaks: this.data[aes + 'breaks'],
+          labels: this.data[aes + 'labels']
+        }));
+    });
+    
   }
 });
 
@@ -234,7 +250,16 @@ AFRAME.registerComponent("plot-area", {
     ybreaks: { default: [] },
     zname: {default: ''},
     zlabels: { default: [] },
-    zbreaks: { default: [] }    
+    zbreaks: { default: [] },
+    colorname: { default: '' },
+    colorbreaks: { default: [] },
+    colorlabels: { default: [] },
+    shapename: { default: '' },
+    shapebreaks: { default: [] },
+    shapelabels: { default: [] },
+    sizename: { default: '' },
+    sizebreaks: { default: [] },
+    sizelabels: { default: [] }
   },
   
   init: function () {
@@ -295,7 +320,17 @@ AFRAME.registerComponent("plot-area", {
                                         ybreaks: dat.ybreaks,
                                         zname: dat.zname,
                                         zlabels: dat.zlabels,
-                                        zbreaks: dat.zbreaks });
+                                        zbreaks: dat.zbreaks,
+                                        colorname: dat.colorname,
+                                        colorbreaks: dat.colorbreaks,
+                                        colorlabels: dat.colorlabels,
+                                        shapename: dat.shapename,
+                                        shapebreaks: dat.shapebreaks,
+                                        shapelabels: dat.shapelabels,
+                                        sizename: dat.sizename,
+                                        sizebreaks: dat.sizebreaks,
+                                        sizelabels: dat.sizelabels
+                                      });
     this.queuePos = 0;
     setTimeout(this.updateCallback.bind(this));
     parent.setAttribute('plot', plotDat);
@@ -392,6 +427,7 @@ AFRAME.registerComponent('plot-axis-text', {
 AFRAME.registerComponent('plot-guide', {
   schema: {
     aesthetic: { default: '' },
+    name: { default: '' },
     breaks: { default: [] },
     labels: { default: [] },
     size: { default: 1 },
@@ -403,7 +439,7 @@ AFRAME.registerComponent('plot-guide', {
       'radius-bottom': 0.01, 'radius-top': 0.001, 'radius-tubular': 0.002,
       shape: 'sphere', color: 'black'
     };
-    this.el.setAttribute('layout', 'type: line; margin: 0.12');
+    this.el.setAttribute('layout', 'type: line; margin: 0.2');
     this.el.setAttribute('static-body', 'shape: box;');
     // add a hidden mesh to stretch the physics body over the text
     this.el.setAttribute('geometry', 'primitive: plane; ' +
@@ -451,7 +487,7 @@ AFRAME.registerComponent('plot-guide', {
       this.labels.appendChild(labEl);
       labEl.setAttribute('scale', new Array(4).join(this.data.fontScale + ' '));
       labEl.setAttribute('bmfont-text', {
-        text: l + '', width: 115, mode: 'nowrap', align: 'right'});
+        text: l + '', width: 200, mode: 'nowrap', align: 'right'});
       this.labels.appendChild(labEl);
     });
   },

--- a/www/components/aframe-plot.js
+++ b/www/components/aframe-plot.js
@@ -42,7 +42,7 @@ AFRAME.registerComponent('plot', {
     this.guideArea = document.createElement('a-entity');
     this.el.append(this.guideArea);
     this.guideArea.setAttribute('position', {
-      x: size / -2 - 0.15, y: size / -2 + 0.02, z: size / -2 - 0.15
+      x: size / -2, y: size / -2, z: size / -2
     });
     this.guideArea.setAttribute('rotation', '0 -45 0');
     this.guideArea.setAttribute('layout', 
@@ -51,7 +51,7 @@ AFRAME.registerComponent('plot', {
       var guideEl = document.createElement('a-entity');
       this.guideArea.appendChild(guideEl);
       guideEl.setAttribute('plot-guide', { 
-        aesthetic: guide, size: (size - 0.06) / 3
+        aesthetic: guide, size: (size - 0.1) / 3
       });
       guideEl.plotEl = this.el;
       this.guides.push(guideEl);
@@ -392,26 +392,44 @@ AFRAME.registerComponent('plot-guide', {
     fontScale: { default: 0.15 }
   },
   init: function() {
+    var ymarg = 0.02;
     this.defaults = { 
       width: 0.01, height: 0.01, depth: 0.01, radius: 0.01, 
       'radius-bottom': 0.01, 'radius-top': 0.001, 'radius-tubular': 0.002,
       shape: 'sphere', color: 'black'
     };
-    this.el.setAttribute('layout', 'type: line; margin: 0.2');
-    this.el.setAttribute('static-body', 'shape: box;');
-    // add a hidden mesh to stretch the physics body over the text
-    this.el.setAttribute('geometry', 'primitive: plane; ' +
-                                      'width: 0.01; height: 0.01;');
-    this.el.setAttribute('material', 'visible: false;');
-    this.el.className += ' hoverable';
     // aesthetic mapping to pass to shiny
-    this.el.axis = this.data.aesthetic; 
+    this.el.axis = this.data.aesthetic;    
+    // drag-drop interaction target
+    this.hoverEl = document.createElement('a-plane');
+    this.el.appendChild(this.hoverEl);
+    this.hoverEl.className += ' hoverable';
+    this.hoverEl.setAttribute('position', {
+      x: -0.75 * this.data.size,
+      y: this.data.size / 2 + ymarg / 2,
+      z: -0.001
+    });
+    this.hoverEl.setAttribute('width', this.data.size * 1.5);
+    this.hoverEl.setAttribute('height', this.data.size);
+    this.hoverEl.setAttribute('color', 'white');
+    this.hoverEl.setAttribute('static-body', '');
+    this.hoverEl.setAttribute('visible', 'false');
+    //layout for the labels v. keys
+    this.legendEl = document.createElement('a-entity');
+    this.el.appendChild(this.legendEl);
+    this.legendEl.setAttribute('position', {
+      x: -0.2, y: ymarg, z: 0
+    });
+    this.legendEl.setAttribute('layout', 'type: line; margin: 0.18');
+    //layout for text labels
     this.labels = document.createElement('a-entity');
-    this.el.appendChild(this.labels);
+    this.legendEl.appendChild(this.labels);
     this.labels.setAttribute('layout', 'type: box');
+    //layout for the legend keys
     this.marks = document.createElement('a-entity');
-    this.el.appendChild(this.marks);
+    this.legendEl.appendChild(this.marks);
     this.marks.setAttribute('layout', 'type: box;');
+
     this.highlight = this.highlight.bind(this);
     this.unHighlight = this.unHighlight.bind(this);
   },
@@ -425,7 +443,6 @@ AFRAME.registerComponent('plot-guide', {
     while(this.labels.lastChild) {
       this.labels.removeChild(this.labels.lastChild);
     }
-    AFRAME.utils.extend(this.defaults, this.data.overrides);
     this.marks.setAttribute('layout', 'margin', 
                          this.data.size / this.data.breaks.length);
     this.labels.setAttribute('layout', 'margin', 
@@ -459,14 +476,10 @@ AFRAME.registerComponent('plot-guide', {
   },
   highlight: function(evt) {
     if(evt.detail.state !== 'hovered') { return; }
-    for(var lab of this.labels.childNodes) {
-      lab.setAttribute('bmfont-text', 'color', '#827d07');
-    }
+    this.hoverEl.setAttribute('visible', 'true');
   },
   unHighlight: function(evt) {
     if(evt.detail.state !== 'hovered') { return; }
-    for(var lab of this.labels.childNodes) {
-      lab.setAttribute('bmfont-text', 'color', '#000');
-    }
+    this.hoverEl.setAttribute('visible', 'false');
   }
 });


### PR DESCRIPTION
Fix #5 Guides added for color/shape/size with hover highlighting and drag-drop mapping. Restructured `plot` component to interface with `shiny at the top level to eliminate redundant storage and messaging of guide and scale data